### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2 
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
-    - uses: elgohr/Publish-Docker-Github-Action@2.14
+    - uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: qassim/qbert-scala
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore